### PR TITLE
Make python 3.7 compatible (issue #16)

### DIFF
--- a/asyncirc/irc.py
+++ b/asyncirc/irc.py
@@ -280,7 +280,7 @@ def disconnected(client_wrapper):
         protocol.wrapper = client_wrapper
         signal("netid-available").send(protocol)
         client_wrapper.protocol = protocol
-    asyncio.async(connector).add_done_callback(reconnected)
+    getattr(asyncio, 'async')(connector).add_done_callback(reconnected)
 
 signal("connection-lost").connect(disconnected)
 


### PR DESCRIPTION
async is a reserved word now, and this shows up as a syntax error in python 3.7. We can still look up the function though, and that is a simple way of keeping the same behavior.

`asyncio.async` function has been deprecated since version 3.4.4 though, so a better fix would be to look at which version of python is running and select the implementation based off of that (the code for that is gross though 😞)

https://github.com/timothycrosley/hug/commit/22e7de475d4a150abe356b175a6d8aa14b8418bf has an example of implementing both fixes